### PR TITLE
Improve action type check

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,7 @@ function checkUniqueDefinition (actionType: string): void {
 }
 
 function checkActionObject (obj): void {
-  invariant(typeof obj === 'object', 'Action Object: Expected an object. Got %s instead', obj)
+  invariant(typeof obj === 'object' && obj !== null, 'Action Object: Expected an object. Got %s instead', obj)
   invariant(typeof obj.creator === 'function', 'Action creator: Expected a function. Got %s instead', obj.creator)
 }
 


### PR DESCRIPTION
Add check for `null` action object to handle the sneaky side-effect of `typeof null === "object"`.

At the moment, running this code:

```js
// this
duck.defineAction("COOL_ACTION", null)
```

would throw this:

```
TypeError: Cannot read property 'creator' of null
```

But we can make it a bit more user-friendly:

```
Invariant Violation: Action Object: Expected an object. Got null instead
```